### PR TITLE
Significantly improve benchmark compilation speed.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,5 +24,10 @@ lazy val bench = project.in(file("bench"))
     Jmh/dependencyClasspath := (Test/dependencyClasspath).value,
     // rewire tasks, so that 'jmh:run' automatically invokes 'jmh:compile' (otherwise a clean 'jmh:run' would fail)
     Jmh/compile := (Jmh/compile).dependsOn(Test/compile).value,
-    Jmh/run := (Jmh/run).dependsOn(Jmh/compile).evaluated
+    Jmh/run := (Jmh/run).dependsOn(Jmh/compile).evaluated,
+
+    // sbt-jmh generates a ton of Java files, but they're never referenced by Scala files.
+    // By enforcing this using `compileOrder`, we avoid having to run these generated files
+    // through the Scala typechecker which has a significant impact on compile-time.
+    Jmh/compileOrder := CompileOrder.ScalaThenJava,
   )


### PR DESCRIPTION
On my machine, this brings down `bench/Jmh/compile` from 1 minute to 7 seconds.