### PR TITLE
Expose strongly connected components on `PrecedenceGraph`

### DIFF
--- a/src/main/scala/datalog/execution/PrecedenceGraph.scala
+++ b/src/main/scala/datalog/execution/PrecedenceGraph.scala
@@ -1,47 +1,57 @@
 package datalog.execution
 
 import datalog.dsl.Atom
-import datalog.tools.Debug.debug
 import datalog.storage.NS
+import datalog.tools.Debug.debug
 
 import scala.collection.mutable
 
-class Node(r: Int) (using ns: NS) {
-  var recursive = false
+private class Node(r: Int)(using ns: NS) {
   val rId: Int = r
   var idx: Int = -1
   var lowLink: Int = -1
   var edges: mutable.Set[Node] = mutable.Set[Node]()
   var onStack: Boolean = false
-  override def toString() =
+
+  def recursive: Boolean = edges.contains(this)
+
+  override def toString(): String =
     "{" + ns(rId) + ": " + "recursive=" + recursive
-//      " idx=" + idx + " lowLink=" + lowLink + " onstack=" + onStack +
-//      " edges=" + edges.map(e => ns(e.rId)).mkString("[", ", ", "]")
+      //      " idx=" + idx + " lowLink=" + lowLink + " onstack=" + onStack +
+      //      " edges=" + edges.map(e => ns(e.rId)).mkString("[", ", ", "]")
       + "}"
 }
 
 class PrecedenceGraph(using ns: NS /* for debugging */) {
-  val nodes: mutable.Map[Int, Node] = mutable.Map[Int, Node]()
-  val sorted: mutable.Queue[mutable.Set[Int]] = mutable.Queue[mutable.Set[Int]]()
-  val idbs: mutable.Set[Int] = mutable.Set[Int]()
+  private val adjacencyList = mutable.Map[Int, mutable.Set[Int]]()
 
-  var index = 0
-  val stack: mutable.Stack[Node] = mutable.Stack[Node]()
-
-  override def toString: String = nodes.map((r, n) => ns(r) + " -> " + n.edges.map(e => ns(e.rId)).mkString("[", ", ", "]")).mkString("{", ", ", "}")
-  def sortedString(): String = sorted.map(cc => cc.map(ns.apply).mkString("(", ", ", ")")).mkString("{", ", ", "}")
-
-  def addNode(rule: Seq[Atom]): Unit = { // TODO: sort incrementally?
-    val node = nodes.getOrElseUpdate(rule.head.rId, Node(rule.head.rId))
-    rule.drop(1).foreach(n => {
-      val neighbor = nodes.getOrElseUpdate(n.rId, Node(n.rId))
-      node.edges.addOne(neighbor)
-      if (n.rId == node.rId) {
-        node.recursive = true
-      }
-    })
+  private def nodes = {
+    val nodes = mutable.Map[Int, Node]()
+    for (from, list) <- adjacencyList do
+      for to <- list do
+        val f = nodes.getOrElseUpdate(from, Node(from))
+        val t = nodes.getOrElseUpdate(to, Node(to))
+        f.edges.addOne(t)
+    nodes.toMap
   }
 
+  // private val nodes: mutable.Map[Int, Node] = mutable.Map[Int, Node]()
+  val idbs: mutable.Set[Int] = mutable.Set[Int]()
+
+  override def toString: String = nodes.map((r, n) => ns(r) + " -> " + n.edges.map(e => ns(e.rId)).mkString("[", ", ", "]")).mkString("{", ", ", "}")
+
+  def sortedString(): String =
+    scc()
+      .map(n => n.map(ns.apply))
+      .map(_.mkString("(", ", ", ")"))
+      .mkString("{", ", ", "}")
+
+  def addNode(rule: Seq[Atom]): Unit = { // TODO: sort incrementally?
+    addNode(rule.head.rId, rule.tail.map(_.rId))
+  }
+
+  // TODO : Store the aliases in another data structure, and use them to compute
+  //        the graph nodes from the adjacency list
   def updateNodeAlias(rId: Int, aliases: mutable.Map[Int, Int]): Unit = {
     val node = nodes(rId)
     node.edges = node.edges.map(edgeNode =>
@@ -50,60 +60,71 @@ class PrecedenceGraph(using ns: NS /* for debugging */) {
   }
 
   def addNode(rId: Int, deps: Seq[Int]): Unit = {
-    val node = nodes.getOrElseUpdate(rId, Node(rId))
-    deps.foreach(n => {
-      val neighbor = nodes.getOrElseUpdate(n, Node(n))
-      node.edges.addOne(neighbor)
-      if (n == rId) {
-        node.recursive = true
-      }
-    })
+    adjacencyList.getOrElseUpdate(rId, mutable.Set[Int]()).addAll(deps)
   }
 
-  def strongConnect(v: Node): Unit = {
-    v.idx = index
-    v.lowLink = index
-    index = index + 1
-    stack.push(v)
-    v.onStack = true
+  private def tarjan(target: Option[Int]): Seq[Set[Int]] = {
+    var index = 0
+    val stack = mutable.Stack[Node]()
+    val sorted = mutable.Queue[mutable.Set[Int]]()
 
-    v.edges.foreach(w => {
-      if (w.idx == -1) { // recur
-        strongConnect(w)
-        v.lowLink = v.lowLink.min(w.lowLink)
-      } else if (w.onStack) {
-        // w is in current scc
-        v.lowLink = v.lowLink.min(w.idx)
+    // TODO: need to indicate recursive anywhere?
+    def strongConnect(v: Node): Unit = {
+      v.idx = index
+      v.lowLink = index
+      index = index + 1
+      stack.push(v)
+      v.onStack = true
+
+      v.edges.foreach(w => {
+        if (w.idx == -1) { // recur
+          strongConnect(w)
+          v.lowLink = v.lowLink.min(w.lowLink)
+        } else if (w.onStack) {
+          // w is in current scc
+          v.lowLink = v.lowLink.min(w.idx)
+        }
+      })
+
+      if (v.lowLink == v.idx) {
+        val res = mutable.Set[Int]()
+        res.addOne(v.rId)
+        while
+          // add to component
+          val w = stack.pop()
+          w.onStack = false
+          res.addOne(w.rId)
+          w.rId != v.rId
+        do {} // TODO: weird?
+        sorted.addOne(res)
       }
-    })
-
-    if (v.lowLink == v.idx) {
-      val res = mutable.Set[Int]()
-      res.addOne(v.rId)
-      while
-        // add to component
-        val w = stack.pop()
-        w.onStack = false
-        res.addOne(w.rId)
-        w.rId != v.rId
-      do {} // TODO: weird?
-      sorted.addOne(res)
     }
-  }
 
-  def topSort(target: Int): Seq[Int] = { // TODO: need to indicate recursive anywhere?
-    debug("precedencegraph:", () => toString())
-    val targetNode = nodes(target)
-//    val targetPlusEdges = (target, targetNode) +: targetNode.edges.toSeq.map(e => (e.rId, e))
-//    val order = targetPlusEdges ++ nodes.filter((i, n) => i != target && !targetNode.edges.contains(n)).toSeq
-    val order = targetNode +: nodes.filter((i, _) => i != target).values.toSeq // Give tarjan a hint
+    // give tarjan a hint
+    val graph = nodes
+    val order = target.map(t => {
+      graph.values.filter(_.rId == t) ++ graph.values.filter(_.rId != t)
+    }).getOrElse(graph.values)
+
     order.foreach(node => {
       if (node.idx == -1) {
         strongConnect(node)
       }
     })
-    val res = sorted.dropRight(sorted.size - 1 - sorted.indexWhere(g => g.contains(target)))
-    res.toSeq.flatMap(s => s.toSeq).filter(r => idbs.contains(r)) // sort and remove edbs
+
+    sorted.map(_.toSet).toSeq
+  }
+
+  def topSort(target: Int): Seq[Int] = {
+    val sorted = tarjan(target = Some(target))
+    sorted
+      .dropRight(sorted.size - 1 - sorted.indexWhere(g => g.contains(target)))
+      .flatMap(s => s.toSeq).filter(r => idbs.contains(r)) // sort and remove edbs
+  }
+
+  def scc(): Seq[Set[Int]] = {
+    debug("precedencegraph:", () => toString())
+    tarjan(target = None).map(_.toSet)
   }
 
   def removeAliases(aliases: mutable.Map[Int, Int]): Unit = {

--- a/src/main/scala/datalog/execution/PrecedenceGraph.scala
+++ b/src/main/scala/datalog/execution/PrecedenceGraph.scala
@@ -24,13 +24,18 @@ private class Node(r: Int)(using ns: NS) {
 
 class PrecedenceGraph(using ns: NS /* for debugging */) {
   private val adjacencyList = mutable.Map[Int, mutable.Set[Int]]()
+  private val aliases = mutable.Map[Int, Int]()
 
   private def nodes = {
+    // Compute a new graph from the adjacency list, respecting alias definitions
     val nodes = mutable.Map[Int, Node]()
     for (from, list) <- adjacencyList do
       for to <- list do
-        val f = nodes.getOrElseUpdate(from, Node(from))
-        val t = nodes.getOrElseUpdate(to, Node(to))
+        val fAlias = aliases.getOrElse(from, from)
+        val tAlias = aliases.getOrElse(to, to)
+
+        val f = nodes.getOrElseUpdate(fAlias, Node(fAlias))
+        val t = nodes.getOrElseUpdate(tAlias, Node(tAlias))
         f.edges.addOne(t)
     nodes.toMap
   }
@@ -53,10 +58,7 @@ class PrecedenceGraph(using ns: NS /* for debugging */) {
   // TODO : Store the aliases in another data structure, and use them to compute
   //        the graph nodes from the adjacency list
   def updateNodeAlias(rId: Int, aliases: mutable.Map[Int, Int]): Unit = {
-    val node = nodes(rId)
-    node.edges = node.edges.map(edgeNode =>
-      nodes(aliases.getOrElse(edgeNode.rId, edgeNode.rId))
-    )
+    this.aliases.addAll(aliases)
   }
 
   def addNode(rId: Int, deps: Seq[Int]): Unit = {

--- a/src/test/scala/test/PrecedenceGraphTest.scala
+++ b/src/test/scala/test/PrecedenceGraphTest.scala
@@ -32,23 +32,25 @@ class PrecedenceGraphTest extends munit.FunSuite {
     t7(x) :- (t5(x), t8(x))
     t10(x) :- t10(x)
 
-
-    val res = engine.precedenceGraph.topSort(t4.id) // test against sorted to keep groups
-    println(res)
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue[mutable.Set[Int]](mutable.Set(8), mutable.Set(2,3,4,5,6,7), mutable.Set(1), mutable.Set(0), mutable.Set(10))
+      engine.precedenceGraph.scc(),
+      Seq(Set(8), Set(2,3,4,5,6,7), Set(1), Set(0), Set(10))
     )
     assertEquals(
-      res,
-      Seq(2,3,4,5,6,7)
+      engine.precedenceGraph.topSort(t10.id),
+      Seq(t10.id),
+    )
+    // There's a single component with the 6 nodes
+    assertEquals(
+      engine.precedenceGraph.topSort(t4.id).toSet,
+      Set(2,3,4,5,6,7)
     )
     assertEquals(
       engine.precedenceGraph.topSort(t8.id),
       Seq() // TODO: empty
     )
   }
-  test("tc with isolated cycle, 1st") {
+  test("tc with isolated cycles") {
     given engine: ExecutionEngine = new SemiNaiveExecutionEngine(new VolcanoStorageManager())
 
     val program = Program(engine)
@@ -74,55 +76,20 @@ class PrecedenceGraphTest extends munit.FunSuite {
     p2(x, z) :- (e2(x, y), p2(y, z))
     other2(x) :- p2("a", x)
 
-    val res = engine.precedenceGraph.topSort(other.id) // test against sorted to keep groups
-
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue[mutable.Set[Int]](mutable.Set(0), mutable.Set(1), mutable.Set(2), mutable.Set(3), mutable.Set(4), mutable.Set(5))
+      engine.precedenceGraph.scc().toSet,
+      Set(Set(0), Set(1), Set(2), Set(3), Set(4), Set(5))
     )
     assertEquals(
-      res,
-      Seq(1, 2)
-    )
-  }
-
-  test("tc with isolated cycle, 2nd") {
-    given engine: ExecutionEngine = new SemiNaiveExecutionEngine(new VolcanoStorageManager())
-
-    val program = Program(engine)
-    val e = program.relation[String]("e")
-    val p = program.relation[String]("p")
-    val other = program.relation[String]("other")
-    val e2 = program.relation[String]("e2")
-    val p2 = program.relation[String]("p2")
-    val other2 = program.relation[String]("other2")
-    val x, y, z = program.variable()
-
-    e("a", "b") :- ()
-    e("b", "c") :- ()
-    e("c", "d") :- ()
-    p(x, y) :- e(x, y)
-    p(x, z) :- (e(x, y), p(y, z))
-    other(x) :- p("a", x)
-
-    e2("a", "b") :- ()
-    e2("b", "c") :- ()
-    e2("c", "d") :- ()
-    p2(x, y) :- e2(x, y)
-    p2(x, z) :- (e2(x, y), p2(y, z))
-    other2(x) :- p2("a", x)
-
-    val res2 = engine.precedenceGraph.topSort(other2.id) // test against sorted to keep groups
-
-    assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue[mutable.Set[Int]](mutable.Set(3), mutable.Set(4), mutable.Set(5), mutable.Set(0), mutable.Set(1), mutable.Set(2))
+      engine.precedenceGraph.topSort(other.id),
+      Seq(p.id, other.id)
     )
     assertEquals(
-      res2,
-      Seq(4, 5)
+      engine.precedenceGraph.topSort(other2.id),
+      Seq(p2.id, other2.id)
     )
   }
+
   test("transitive closure") {
     given engine: ExecutionEngine = new SemiNaiveExecutionEngine(new VolcanoStorageManager())
     val program = Program(engine)
@@ -140,8 +107,8 @@ class PrecedenceGraphTest extends munit.FunSuite {
 
     engine.precedenceGraph.topSort(other.id) // test against sorted to keep groups
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue[mutable.Set[Int]](mutable.Set(0), mutable.Set(1), mutable.Set(2))
+      engine.precedenceGraph.scc(),
+      Seq(Set(0), Set(1), Set(2))
     )
   }
 
@@ -160,8 +127,8 @@ class PrecedenceGraphTest extends munit.FunSuite {
 
     engine.precedenceGraph.topSort(a.id)
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue(mutable.Set(3), mutable.Set(0, 1, 2))
+      engine.precedenceGraph.scc(),
+      Seq(Set(3), Set(0, 1, 2))
     )
   }
 
@@ -181,8 +148,8 @@ class PrecedenceGraphTest extends munit.FunSuite {
 
     engine.precedenceGraph.topSort(a.id)
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue(mutable.Set(3), mutable.Set(0, 1, 2))
+      engine.precedenceGraph.scc(),
+      Seq(Set(3), Set(0, 1, 2))
     )
   }
 
@@ -202,8 +169,8 @@ class PrecedenceGraphTest extends munit.FunSuite {
 
     engine.precedenceGraph.topSort(a.id)
     assertEquals(
-      engine.precedenceGraph.sorted,
-      mutable.Queue(mutable.Set(3), mutable.Set(0, 1, 2))
+      engine.precedenceGraph.scc(),
+      Seq(Set(3), Set(0, 1, 2))
     )
   }
 


### PR DESCRIPTION
This PR includes the following changes:

- [x] `PrecedenceGraph` now exposes the strongly connected components through its `.scc` method.
- [x] It's now possible to call `topSort` multiples times on the same instance of `PrecedenceGraph`.
- [x] The implementation-specific attributes of `PrecedenceGraph` have either been marked as `private` or removed.
- [x] Handle alias updates in `PrecedenceGraph`.

