### PR TITLE
Implement stratification in `SemiNaiveExecutionEngine`

### DIFF
--- a/src/main/scala/datalog/execution/PrecedenceGraph.scala
+++ b/src/main/scala/datalog/execution/PrecedenceGraph.scala
@@ -138,10 +138,6 @@ class PrecedenceGraph(using ns: NS /* for debugging */) {
 
   def scc(): Seq[Set[Int]] = {
     debug("precedencegraph:", () => toString())
-    tarjan(target = None).map(_.toSet)
-  }
-
-  def removeAliases(aliases: mutable.Map[Int, Int]): Unit = {
-
+    tarjan(target = None)
   }
 }

--- a/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
@@ -46,12 +46,12 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     })
   }
 
-  override def solve(toSolve: RelationId): Set[Seq[Term]] = {
+  override def solve(rId: RelationId): Set[Seq[Term]] = {
     storageManager.verifyEDBs(idbs.keys.to(mutable.Set))
-    if (storageManager.edbContains(toSolve) && !idbs.contains(toSolve)) { // if just an edb predicate then return
-      return storageManager.getEDBResult(toSolve)
+    if (storageManager.edbContains(rId) && !idbs.contains(rId)) { // if just an edb predicate then return
+      return storageManager.getEDBResult(rId)
     }
-    if (!idbs.contains(toSolve)) {
+    if (!idbs.contains(rId)) {
       throw new Exception("Solving for rule without body")
     }
     // TODO: if a IDB predicate without vars, then solve all and test contains result?
@@ -60,7 +60,7 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     val strata = precedenceGraph.scc()
     storageManager.initEvaluation() // facts previously derived
 
-    debug(s"solving relation: ${storageManager.ns(toSolve)} order of relations=", strata.toString)
+    debug(s"solving relation: ${storageManager.ns(rId)} order of relations=", strata.toString)
 
     var scount = 0
     // for each stratum
@@ -77,12 +77,12 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
 
         debug(s"initial state @ $count", storageManager.printer.toString)
         count += 1
-        evalSN(toSolve, relations.toSeq)
+        evalSN(rId, relations.toSeq)
         setDiff = storageManager.compareNewDeltaDBs()
       }
       debug(s"final state @$count", storageManager.printer.toString)
       storageManager.updateDiscovered()
     )
-    storageManager.getNewIDBResult(toSolve)
+    storageManager.getNewIDBResult(rId)
   }
 }

--- a/src/main/scala/datalog/main.scala
+++ b/src/main/scala/datalog/main.scala
@@ -77,10 +77,12 @@ def ackermann(program: Program) = {
 def tc(program: Program): Unit = {
   val edge = program.relation[Constant]("edge")
   val path = program.relation[Constant]("path")
+  val path2a = program.relation[Constant]("path2a")
   val x, y, z = program.variable()
 
   path(x, y) :- edge(x, y)
-  path(x, z) :- (edge(x, y), path(y, z), edge(y, "a"))
+  path(x, z) :- (edge(x, y), path(y, z))
+  path2a(x, y) :- (path(x, y), edge(y, "a"))
 
   edge("a", "a", "red") :- ()
   edge("a", "b", "blue") :- ()
@@ -650,13 +652,13 @@ def isAfter(program: Program) =
 //  acyclic(program0)
 //  println("\n\n_______________________\n\n")
 
-  val dotty = staging.Compiler.make(getClass.getClassLoader)
-  var sort = 1
-//    println(s"OLD SN: $sort")
-//    given engine1: ExecutionEngine = new SemiNaiveExecutionEngine(new DefaultStorageManager())
-//    val program1 = Program(engine1)
-//    func(program1)
-//    println("\n\n_______________________\n\n")
+//  val dotty = staging.Compiler.make(getClass.getClassLoader)
+//  var sort = 1
+//  println(s"OLD SN: $sort")
+  given engine1: ExecutionEngine = new NaiveExecutionEngine(new DefaultStorageManager())
+  val program1 = Program(engine1)
+  tc(program1)
+  println("\n\n_______________________\n\n")
 
 //    val jo2 = JITOptions(ir.OpCode.OTHER, dotty, aot = false, block = true)
 //    println("INTERP")
@@ -666,12 +668,12 @@ def isAfter(program: Program) =
 //    isEqual(program3a)
 //    println("\n\n_______________________\n\n")
 //
-    val jo = JITOptions(ir.OpCode.EVAL_RULE_SN, dotty, aot = false, block = true, sortOrder = (0, 0, 0))
-    println("JIT")
-    given engine3: ExecutionEngine = new StagedExecutionEngine(new DefaultStorageManager(), jo)
-    val program3 = Program(engine3)
-    ackermann(program3)
-    println("\n\n_______________________\n\n")
+//    val jo = JITOptions(ir.OpCode.EVAL_RULE_SN, dotty, aot = false, block = true, sortOrder = (0, 0, 0))
+//    println("JIT")
+//    given engine3: ExecutionEngine = new StagedExecutionEngine(new DefaultStorageManager(), jo)
+//    val program3 = Program(engine3)
+//    ackermann(program3)
+//    println("\n\n_______________________\n\n")
 
 //  println("JIT Snippet")
 //  val engine4: ExecutionEngine = new StagedSnippetExecutionEngine(new DefaultStorageManager(), jo)

--- a/src/main/scala/datalog/storage/CollectionsStorageManager.scala
+++ b/src/main/scala/datalog/storage/CollectionsStorageManager.scala
@@ -9,11 +9,12 @@ import scala.collection.{Iterator, immutable, mutable}
 
 abstract class CollectionsStorageManager(override val ns: NS) extends StorageManager(ns) {
   // "database", i.e. relationID => Relation
-  protected val edbs: CollectionsDatabase = CollectionsDatabase()
+  protected val edbs: CollectionsDatabase = CollectionsDatabase() // raw user-supplied EDBs from initialization.
+  protected val discoveredFacts: CollectionsDatabase = CollectionsDatabase() // all EDBs + facts discovered in previous strata
   var knownDbId: KnowledgeId = -1
   var newDbId: KnowledgeId = -1
 
-  // dbID => database, because we swap between read (known) and write (new)
+  // dbID => database, because we swap between read (known) and write (new) within iterations
   var dbId = 0
   protected val derivedDB: mutable.Map[KnowledgeId, CollectionsDatabase] = mutable.Map[KnowledgeId, CollectionsDatabase]()
   protected val deltaDB: mutable.Map[KnowledgeId, CollectionsDatabase] = mutable.Map[KnowledgeId, CollectionsDatabase]()
@@ -41,6 +42,7 @@ abstract class CollectionsStorageManager(override val ns: NS) extends StorageMan
 
     edbs.foreach((k, relation) => {
       deltaDB(dbId)(k) = CollectionsEDB()
+      discoveredFacts(k) = relation
     }) // Delta-EDB is just empty sets
     dbId += 1
 
@@ -69,13 +71,13 @@ abstract class CollectionsStorageManager(override val ns: NS) extends StorageMan
 
   // Read intermediate results
   def getKnownDerivedDB(rId: RelationId): CollectionsEDB =
-    derivedDB(knownDbId).getOrElse(rId, edbs.getOrElse(rId, CollectionsEDB()))
+    derivedDB(knownDbId).getOrElse(rId, discoveredFacts.getOrElse(rId, CollectionsEDB()))
   def getNewDerivedDB(rId: RelationId): CollectionsEDB =
-    derivedDB(newDbId).getOrElse(rId, edbs.getOrElse(rId, CollectionsEDB()))
+    derivedDB(newDbId).getOrElse(rId, discoveredFacts.getOrElse(rId, CollectionsEDB()))
   def getKnownDeltaDB(rId: RelationId): CollectionsEDB =
-    deltaDB(knownDbId).getOrElse(rId, edbs.getOrElse(rId, CollectionsEDB()))
+    deltaDB(knownDbId).getOrElse(rId, discoveredFacts.getOrElse(rId, CollectionsEDB()))
   def getNewDeltaDB(rId: RelationId): CollectionsEDB =
-    deltaDB(newDbId).getOrElse(rId, edbs.getOrElse(rId, CollectionsEDB()))
+    deltaDB(newDbId).getOrElse(rId, discoveredFacts.getOrElse(rId, CollectionsEDB()))
 
   // Read final results
   def getKnownIDBResult(rId: RelationId): Set[Seq[Term]] =
@@ -101,8 +103,7 @@ abstract class CollectionsStorageManager(override val ns: NS) extends StorageMan
   def resetNewDelta(rId: RelationId, rules: EDB): Unit =
     deltaDB(newDbId)(rId) = asCollectionsEDB(rules)
   def clearNewDerived(): Unit =
-    derivedDB(newDbId).foreach((i, e) => e.clear())
-
+    derivedDB(newDbId) = CollectionsDatabase()
   // Compare & Swap
   def swapKnowledge(): Unit = {
     iteration += 1
@@ -114,6 +115,15 @@ abstract class CollectionsStorageManager(override val ns: NS) extends StorageMan
     deltaDB(newDbId).exists((k, v) => v.nonEmpty)
   def compareDerivedDBs(): Boolean =
     derivedDB(knownDbId) == derivedDB(newDbId)
+
+  /**
+   * Copy all the derived facts at the end of the current strata into discoveredFacts
+   * to be fed into the next strata as EDBs
+    */
+  def updateDiscovered(): Unit =
+    derivedDB(knownDbId).foreach((relation, facts) =>
+      discoveredFacts(relation) = facts
+    )
 
   def verifyEDBs(idbList: mutable.Set[RelationId]): Unit = {
     ns.rIds().foreach(rId =>
@@ -140,6 +150,7 @@ abstract class CollectionsStorageManager(override val ns: NS) extends StorageMan
 
     "+++++\n" +
       "EDB:" + printer.edbToString(edbs) +
+      "\nFACTS:" + printer.edbToString(discoveredFacts) +
       "\nDERIVED:" + derivedDB.map(printHelperRelation).mkString("[", ", ", "]") +
       "\nDELTA:" + deltaDB.map(printHelperRelation).mkString("[", ", ", "]") +
       "\n+++++"

--- a/src/main/scala/datalog/storage/DefaultStorageManager.scala
+++ b/src/main/scala/datalog/storage/DefaultStorageManager.scala
@@ -229,10 +229,10 @@ class DefaultStorageManager(ns: NS = new NS()) extends CollectionsStorageManager
                 if (r == d && !found && i > idx) {
                   found = true
                   idx = i
-                  deltaDB(knownDbId)(r)
+                  getKnownDeltaDB(r)
                 }
                 else {
-                  derivedDB(knownDbId).getOrElse(r, edbs.getOrElse(r, CollectionsEDB())) // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB
+                  getKnownDerivedDB(r) // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB
                 }
               ), k, (0, 0, 0)).wrapped // don't sort when not staging
           }).distinct
@@ -248,7 +248,7 @@ class DefaultStorageManager(ns: NS = new NS()) extends CollectionsStorageManager
         else
           projectHelper(
             joinHelper(
-              k.deps.map(r => derivedDB(knownDbId).getOrElse(r, edbs.getOrElse(r, CollectionsEDB()))), k // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB)
+              k.deps.map(r => getKnownDerivedDB(r)), k // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB)
             ), k
           ).wrapped.distinct
       })

--- a/src/main/scala/datalog/storage/StorageManager.scala
+++ b/src/main/scala/datalog/storage/StorageManager.scala
@@ -40,6 +40,7 @@ trait StorageManager(val ns: NS) {
   def swapKnowledge(): Unit
   def compareNewDeltaDBs(): Boolean
   def compareDerivedDBs(): Boolean
+  def updateDiscovered(): Unit
 
   def verifyEDBs(idbList: mutable.Set[RelationId]): Unit
 

--- a/src/main/scala/datalog/storage/VolcanoStorageManager.scala
+++ b/src/main/scala/datalog/storage/VolcanoStorageManager.scala
@@ -33,8 +33,10 @@ class VolcanoStorageManager(ns: NS = NS()) extends CollectionsStorageManager(ns)
             Scan(edbs.getOrElse(rId, CollectionsEDB()), rId)
           else
             Project(
-              Join(k.deps.map(r => Scan(
-                derivedDB(knownDbId).getOrElse(r, edbs.getOrElse(r, CollectionsEDB())), r) // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB
+              Join(k.deps.map(r =>
+                Scan(
+                  getKnownDerivedDB(r), r
+                ) // TODO: warn if EDB is empty? Right now can't tell the difference between undeclared and empty EDB
               ), k.varIndexes, k.constIndexes),
               k.projIndexes
             )
@@ -68,9 +70,9 @@ class VolcanoStorageManager(ns: NS = NS()) extends CollectionsStorageManager(ns)
                     if (r == d && !found && i > idx)
                       found = true
                       idx = i
-                      Scan(deltaDB(knownDbId).getOrElse(r, CollectionsEDB()), r)
+                      Scan(getKnownDeltaDB(r), r)
                     else
-                      Scan(derivedDB(knownDbId).getOrElse(r, edbs.getOrElse(r, CollectionsEDB())), r)
+                      Scan(getKnownDerivedDB(r), r)
                   }),
                   k.varIndexes,
                   k.constIndexes

--- a/src/test/scala/test/examples/strata/expected/q.csv
+++ b/src/test/scala/test/examples/strata/expected/q.csv
@@ -1,0 +1,7 @@
+String	String	String
+a	b	c
+b	c	a
+c	a	b
+x	y	z
+y	z	x
+z	x	y

--- a/src/test/scala/test/examples/strata/strata.scala
+++ b/src/test/scala/test/examples/strata/strata.scala
@@ -1,0 +1,32 @@
+package test.examples.strata
+
+import datalog.dsl.{Constant, Program}
+import test.ExampleTestGenerator
+
+class strata_test extends ExampleTestGenerator("strata") with strata
+
+trait strata {
+  val toSolve = "_"
+
+  def pretest(program: Program): Unit = {
+    val b = program.relation[Constant]("e")
+    val p1 = program.relation[Constant]("p1")
+    val p2 = program.relation[Constant]("p2")
+    val p3 = program.relation[Constant]("p3")
+    val q = program.relation[Constant]("q")
+    val x, y, z = program.variable()
+
+    // p1, p2 and p3 are in the same stratum
+    p1(x, y, z) :- b(x, y, z)
+    p1(x, y, z) :- p2(y, z, x)
+    p2(x, y, z) :- b(x, y, z)
+    p2(x, y, z) :- p3(y, z, x)
+    p3(x, y, z) :- b(x, y, z)
+    p3(x, y, z) :- p1(y, z, x)
+
+    q(x, y, z) :- (p1(x, y, z), p2(x, y, z), p3(x, y, z))
+
+    b("a", "b", "c") :- ()
+    b("x", "y", "z") :- ()
+  }
+}


### PR DESCRIPTION
This PR is based on #27 and adds stratification to the `SemiNaiveExecutionEngine`. It includes the following changes:

- [x] `def solve(rId: RelationId)` now uses the strongly connected components from the `PrecedenceGraph` to compute the relations.