### PR TITLE
Implement stratification in `SemiNaiveExecutionEngine`

### DIFF
--- a/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
@@ -46,12 +46,12 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     })
   }
 
-  override def solve(toSolve: RelationId): Set[Seq[Term]] = {
+  override def solve(rId: RelationId): Set[Seq[Term]] = {
     storageManager.verifyEDBs(idbs.keys.to(mutable.Set))
-    if (storageManager.edbContains(toSolve) && !idbs.contains(toSolve)) { // if just an edb predicate then return
-      return storageManager.getEDBResult(toSolve)
+    if (storageManager.edbContains(rId) && !idbs.contains(rId)) { // if just an edb predicate then return
+      return storageManager.getEDBResult(rId)
     }
-    if (!idbs.contains(toSolve)) {
+    if (!idbs.contains(rId)) {
       throw new Exception("Solving for rule without body")
     }
     // TODO: if a IDB predicate without vars, then solve all and test contains result?
@@ -60,7 +60,7 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     val strata = precedenceGraph.scc()
     storageManager.initEvaluation() // facts previously derived
 
-    debug(s"solving relation: ${storageManager.ns(toSolve)} order of relations=", strata.toString)
+    debug(s"solving relation: ${storageManager.ns(rId)} order of relations=", strata.toString)
 
     var scount = 0
     // for each stratum
@@ -77,12 +77,12 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
 
         debug(s"initial state @ $count", storageManager.printer.toString)
         count += 1
-        evalSN(toSolve, relations.toSeq)
+        evalSN(rId, relations.toSeq)
         setDiff = storageManager.compareNewDeltaDBs()
       }
       debug(s"final state @$count", storageManager.printer.toString)
       storageManager.updateDiscovered()
     )
-    storageManager.getNewIDBResult(toSolve)
+    storageManager.getNewIDBResult(rId)
   }
 }

--- a/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
@@ -67,7 +67,7 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     strata.foreach(r =>
       val relations = r.toSeq             
       var count = 0
-      println(s"\n\n*****STRATA $scount with relations $relations")
+      debug("", () => s"\n\n*****STRATA $scount with relations $relations")
       scount += 1
 
       evalNaive(relations, true) // this fills derived[new] and delta[new]

--- a/src/test/scala/test/examples/strata/expected/q.csv
+++ b/src/test/scala/test/examples/strata/expected/q.csv
@@ -1,0 +1,7 @@
+String	String	String
+a	b	c
+b	c	a
+c	a	b
+x	y	z
+y	z	x
+z	x	y

--- a/src/test/scala/test/examples/strata/strata.scala
+++ b/src/test/scala/test/examples/strata/strata.scala
@@ -1,0 +1,32 @@
+package test.examples.strata
+
+import datalog.dsl.{Constant, Program}
+import test.ExampleTestGenerator
+
+class strata_test extends ExampleTestGenerator("strata") with strata
+
+trait strata {
+  val toSolve = "_"
+
+  def pretest(program: Program): Unit = {
+    val b = program.relation[Constant]("e")
+    val p1 = program.relation[Constant]("p1")
+    val p2 = program.relation[Constant]("p2")
+    val p3 = program.relation[Constant]("p3")
+    val q = program.relation[Constant]("q")
+    val x, y, z = program.variable()
+
+    // p1, p2 and p3 are in the same stratum
+    p1(x, y, z) :- b(x, y, z)
+    p1(x, y, z) :- p2(y, z, x)
+    p2(x, y, z) :- b(x, y, z)
+    p2(x, y, z) :- p3(y, z, x)
+    p3(x, y, z) :- b(x, y, z)
+    p3(x, y, z) :- p1(y, z, x)
+
+    q(x, y, z) :- (p1(x, y, z), p2(x, y, z), p3(x, y, z))
+
+    b("a", "b", "c") :- ()
+    b("x", "y", "z") :- ()
+  }
+}


### PR DESCRIPTION
This PR is based on #27 and adds stratification to the `SemiNaiveExecutionEngine`. It includes the following changes:

- [x] `def solve(rId: RelationId)` now uses the strongly connected components from the `PrecedenceGraph` to compute the relations.
- [x] the new test `strata` validates the behavior when multiple predicates are derived within a single stratum.
