### PR TITLE
Implement stratification in `StagedExecutionEngine`

### DIFF
--- a/src/main/scala/datalog/execution/NaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/NaiveExecutionEngine.scala
@@ -74,7 +74,7 @@ class NaiveExecutionEngine(val storageManager: StorageManager) extends Execution
     if (!idbs.contains(toSolve)) {
       throw new Exception("Solving for rule without body")
     }
-    val strata = precedenceGraph.scc()
+    val strata = precedenceGraph.scc(toSolve)
     storageManager.initEvaluation() // facts discovered in the previous iteration
 
     debug(s"solving relation: ${storageManager.ns(toSolve)} order of relations=", strata.toString)

--- a/src/main/scala/datalog/execution/PrecedenceGraph.scala
+++ b/src/main/scala/datalog/execution/PrecedenceGraph.scala
@@ -140,4 +140,13 @@ class PrecedenceGraph(using ns: NS /* for debugging */) {
     debug("precedencegraph:", () => toString())
     tarjan(target = None)
   }
+
+  def scc(target: Int): Seq[Set[Int]] = {
+    val sorted = tarjan(target = Some(target))
+    sorted
+      .dropRight(sorted.size - 1 - sorted.indexWhere(g => g.contains(target)))
+      .map(_.toSet)
+      .map(_.intersect(idbs)) // sort and remove edbs
+      .filter(_.nonEmpty)
+  }
 }

--- a/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
@@ -67,7 +67,7 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     strata.foreach(r =>
       val relations = r.toSeq
       var count = 0
-      println(s"\n\n*****STRATA $scount with relations $relations")
+      debug("", () => s"\n\n*****STRATA $scount with relations $relations")
       scount += 1
 
       evalNaive(relations, true) // this fills derived[new] and delta[new]

--- a/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/SemiNaiveExecutionEngine.scala
@@ -57,7 +57,7 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     // TODO: if a IDB predicate without vars, then solve all and test contains result?
     //    if (relations.isEmpty)
     //      return Set()
-    val strata = precedenceGraph.scc()
+    val strata = precedenceGraph.scc(rId)
     storageManager.initEvaluation() // facts previously derived
 
     debug(s"solving relation: ${storageManager.ns(rId)} order of strata=", strata.toString)
@@ -65,9 +65,9 @@ class SemiNaiveExecutionEngine(override val storageManager: StorageManager) exte
     var scount = 0
     // for each stratum
     strata.foreach(r =>
-      val relations = r.toSeq             
+      val relations = r.toSeq
       var count = 0
-      debug("", () => s"\n\n*****STRATA $scount with relations $relations")
+      println(s"\n\n*****STRATA $scount with relations $relations")
       scount += 1
 
       evalNaive(relations, true) // this fills derived[new] and delta[new]

--- a/src/main/scala/datalog/execution/StagedCompiler.scala
+++ b/src/main/scala/datalog/execution/StagedCompiler.scala
@@ -160,6 +160,9 @@ class StagedCompiler(val storageManager: StorageManager)(using val jitOptions: J
           }) ()
         }
 
+      case UpdateDiscoveredOp() =>
+        '{ $stagedSM.updateDiscovered() }
+
       case SwapAndClearOp() =>
         '{ $stagedSM.swapKnowledge() ; $stagedSM.clearNewDerived() }
 
@@ -175,9 +178,8 @@ class StagedCompiler(val storageManager: StorageManager)(using val jitOptions: J
               '{ $acc ; def eval_sn_lambda() = $next; eval_sn_lambda() }
             )
           case _ =>
-            cOps.reduceLeft((acc, next) => // TODO[future]: make a block w reflection instead of reduceLeft for efficiency
-              '{ $acc ; $next }
-            )
+            // TODO[future]: make a block w reflection instead of reduceLeft for efficiency
+            cOps.foldRight('{ () })((next, acc) => '{ $next ; $acc })
 
       case InsertOp(rId, db, knowledge, children:_*) =>
         val res = compileIRRelOp(children.head.asInstanceOf[IROp[EDB]])

--- a/src/main/scala/datalog/execution/StagedCompiler.scala
+++ b/src/main/scala/datalog/execution/StagedCompiler.scala
@@ -178,8 +178,9 @@ class StagedCompiler(val storageManager: StorageManager)(using val jitOptions: J
               '{ $acc ; def eval_sn_lambda() = $next; eval_sn_lambda() }
             )
           case _ =>
-            // TODO[future]: make a block w reflection instead of reduceLeft for efficiency
-            cOps.foldRight('{ () })((next, acc) => '{ $next ; $acc })
+            cOps.reduceLeft((acc, next) =>
+                 '{ $acc ; $next }
+             )
 
       case InsertOp(rId, db, knowledge, children:_*) =>
         val res = compileIRRelOp(children.head.asInstanceOf[IROp[EDB]])

--- a/src/main/scala/datalog/execution/StagedExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/StagedExecutionEngine.scala
@@ -181,6 +181,8 @@ class StagedExecutionEngine(val storageManager: StorageManager, val defaultJITOp
       case op: SequenceOp =>
         op.run_continuation(storageManager, op.children.map(o => (sm: StorageManager) => jit(o)))
 
+      case op: UpdateDiscoveredOp =>
+        op.run(storageManager)
 
       case op: SwapAndClearOp =>
         op.run(storageManager)

--- a/src/main/scala/datalog/execution/StagedExecutionEngine.scala
+++ b/src/main/scala/datalog/execution/StagedExecutionEngine.scala
@@ -25,7 +25,7 @@ class StagedExecutionEngine(val storageManager: StorageManager, val defaultJITOp
   compiler.clearDottyThread()
   var stragglers: mutable.WeakHashMap[Int, Future[CompiledFn[?]]] = mutable.WeakHashMap.empty // should be ok since we are only removing by ref and then iterating on values only?
 
-  def createIR(ast: ASTNode)(using InterpreterContext): IROp[Any] = IRTreeGenerator().generateSemiNaive(ast)
+  def createIR(ast: ASTNode)(using InterpreterContext): IROp[Any] = IRTreeGenerator().generateTopLevelProgram(ast, naive=false)
 
   def initRelation(rId: Int, name: String): Unit = {
     storageManager.ns(rId) = name
@@ -368,5 +368,5 @@ class StagedExecutionEngine(val storageManager: StorageManager, val defaultJITOp
   }
 }
 class NaiveStagedExecutionEngine(storageManager: StorageManager, defaultJITOptions: JITOptions = JITOptions()) extends StagedExecutionEngine(storageManager, defaultJITOptions) {
-  override def createIR(ast: ASTNode)(using InterpreterContext): IROp[Any] = IRTreeGenerator().generateNaive(ast)
+  override def createIR(ast: ASTNode)(using InterpreterContext): IROp[Any] = IRTreeGenerator().generateTopLevelProgram(ast, naive=true)
 }

--- a/src/main/scala/datalog/execution/StagedSnippetCompiler.scala
+++ b/src/main/scala/datalog/execution/StagedSnippetCompiler.scala
@@ -124,6 +124,9 @@ class StagedSnippetCompiler(val storageManager: StorageManager)(using val jitOpt
           }) ()
         }
 
+      case UpdateDiscoveredOp() =>
+        '{ $stagedSM.updateDiscovered() }
+
       case SwapAndClearOp() =>
         '{ $stagedSM.swapKnowledge() ; $stagedSM.clearNewDerived() }
 

--- a/src/main/scala/datalog/execution/ir/IROp.scala
+++ b/src/main/scala/datalog/execution/ir/IROp.scala
@@ -14,8 +14,9 @@ import scala.quoted.*
 import scala.util.{Failure, Success}
 
 enum OpCode:
-  case PROGRAM, SWAP_CLEAR, SEQ, SCAN, SCANEDB, SPJ, INSERT, UNION, DIFF, DEBUG, DEBUGP, DOWHILE,
-  EVAL_RULE_NAIVE, EVAL_RULE_SN, EVAL_RULE_BODY, EVAL_NAIVE, EVAL_SN, LOOP_BODY, OTHER // convenience labels for generating functions
+  case PROGRAM, SWAP_CLEAR, SEQ, SCAN, SCANEDB, SPJ, INSERT, UNION, DIFF, 
+  DEBUG, DEBUGP, DOWHILE, UPDATE_DISCOVERED,
+  EVAL_STRATA, EVAL_STRATUM, EVAL_RULE_NAIVE, EVAL_RULE_SN, EVAL_RULE_BODY, EVAL_NAIVE, EVAL_SN, LOOP_BODY, OTHER // convenience labels for generating functions
 object OpCode {
   def relational(opCode: OpCode): Boolean =
     Seq(SCAN, OpCode.SCANEDB, OpCode.SPJ, OpCode.UNION, OpCode.DIFF, OpCode.EVAL_RULE_BODY, OpCode.EVAL_RULE_NAIVE, OpCode.EVAL_RULE_SN).contains(opCode)
@@ -119,6 +120,16 @@ case class SequenceOp(override val code: OpCode, override val children:IROp[Any]
     opFns.map(o => o(storageManager))
   override def run(storageManager: StorageManager): Any =
     children.map(o => o.run(storageManager))
+}
+
+case class UpdateDiscoveredOp()(using JITOptions) extends IROp[Any] {
+  val code: OpCode = OpCode.UPDATE_DISCOVERED
+  override def run(storageManager: StorageManager): Any =
+    storageManager.updateDiscovered()
+
+  override def run_continuation(storageManager: StorageManager, 
+                                opFns: Seq[CompiledFn[Any]]): Any =
+    run(storageManager)
 }
 
 case class SwapAndClearOp()(using JITOptions) extends IROp[Any] {

--- a/src/main/scala/datalog/execution/ir/IROp.scala
+++ b/src/main/scala/datalog/execution/ir/IROp.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success}
 enum OpCode:
   case PROGRAM, SWAP_CLEAR, SEQ, SCAN, SCANEDB, SPJ, INSERT, UNION, DIFF, 
   DEBUG, DEBUGP, DOWHILE, UPDATE_DISCOVERED,
-  EVAL_STRATA, EVAL_STRATUM, EVAL_RULE_NAIVE, EVAL_RULE_SN, EVAL_RULE_BODY, EVAL_NAIVE, EVAL_SN, LOOP_BODY, OTHER // convenience labels for generating functions
+  EVAL_STRATUM, EVAL_RULE_NAIVE, EVAL_RULE_SN, EVAL_RULE_BODY, EVAL_NAIVE, EVAL_SN, LOOP_BODY, OTHER // convenience labels for generating functions
 object OpCode {
   def relational(opCode: OpCode): Boolean =
     Seq(SCAN, OpCode.SCANEDB, OpCode.SPJ, OpCode.UNION, OpCode.DIFF, OpCode.EVAL_RULE_BODY, OpCode.EVAL_RULE_NAIVE, OpCode.EVAL_RULE_SN).contains(opCode)

--- a/src/main/scala/datalog/execution/ir/IRTreeGenerator.scala
+++ b/src/main/scala/datalog/execution/ir/IRTreeGenerator.scala
@@ -1,14 +1,14 @@
 package datalog.execution.ir
 
-import datalog.execution.{JITOptions, StagedCompiler}
+import datalog.execution.{JITOptions, StagedCompiler, ir}
 import datalog.execution.ast.{ASTNode, AllRulesNode, LogicAtom, ProgramNode, RuleNode}
-import datalog.storage.{StorageManager, DB, KNOWLEDGE, RelationId, EDB}
+import datalog.storage.{DB, EDB, KNOWLEDGE, RelationId, StorageManager}
 import datalog.tools.Debug.debug
 
-import scala.collection.mutable
+import scala.collection.{MapView, mutable}
 
 class IRTreeGenerator(using val ctx: InterpreterContext)(using JITOptions) {
-  def naiveEval(ruleMap: mutable.Map[RelationId, ASTNode], copyToDelta: Boolean = false): IROp[Any] =
+  def naiveEval(ruleMap: MapView[RelationId, ASTNode], copyToDelta: Boolean = false): IROp[Any] =
     SequenceOp(
       OpCode.EVAL_NAIVE,
       //      DebugNode("in eval:", () => s"rId=${ctx.storageManager.ns(rId)} relations=${ctx.relations.map(r => ctx.storageManager.ns(r)).mkString("[", ", ", "]")}  incr=${ctx.newDbId} src=${ctx.knownDbId}") +:
@@ -25,7 +25,7 @@ class IRTreeGenerator(using val ctx: InterpreterContext)(using JITOptions) {
         ):_*
     )
 
-  def semiNaiveEval(rId: RelationId, ruleMap: mutable.Map[RelationId, ASTNode]): IROp[Any] =
+  def semiNaiveEval(rId: RelationId, ruleMap: MapView[RelationId, ASTNode]): IROp[Any] =
     SequenceOp(
       OpCode.EVAL_SN,
       ctx.sortedRelations
@@ -109,12 +109,23 @@ class IRTreeGenerator(using val ctx: InterpreterContext)(using JITOptions) {
   def generateNaive(ast: ASTNode): IROp[Any] = {
     ast match {
       case ProgramNode(ruleMap) =>
-        DoWhileOp(
-          DB.Derived,
-          SequenceOp(OpCode.LOOP_BODY,
-            SwapAndClearOp(),
-            naiveEval(ruleMap)
-          )
+        val scc = ctx.precedenceGraph.scc(ctx.toSolve)
+        val stratum = scc.map(rels => ruleMap.view.filterKeys(rels.contains))
+        ProgramOp(
+          SequenceOp(OpCode.EVAL_STRATA,
+             stratum.map(rules =>
+               SequenceOp(OpCode.EVAL_STRATUM,
+                 DoWhileOp(
+                   DB.Derived,
+                   SequenceOp(OpCode.LOOP_BODY,
+                     SwapAndClearOp(),
+                     naiveEval(rules)
+                   ),
+                 ),
+                 UpdateDiscoveredOp(),
+               )
+            ): _*
+          ),
         )
       case _ => throw new Exception("Non-root passed to IR Program")
     }
@@ -123,16 +134,25 @@ class IRTreeGenerator(using val ctx: InterpreterContext)(using JITOptions) {
   def generateSemiNaive(ast: ASTNode): IROp[Any] = {
     ast match {
       case ProgramNode(ruleMap) =>
-        ProgramOp(SequenceOp(OpCode.SEQ,
-          naiveEval(ruleMap, true),
-          DoWhileOp(
-            DB.Delta,
-            SequenceOp(OpCode.LOOP_BODY,
-              SwapAndClearOp(),
-              semiNaiveEval(ctx.toSolve, ruleMap)
-            )
-          )
-        ))
+        val scc = ctx.precedenceGraph.scc(ctx.toSolve)
+        val stratum = scc.map(rels => ruleMap.view.filterKeys(rels.contains))
+        ProgramOp(
+          SequenceOp(OpCode.EVAL_STRATA,
+            stratum.map(rules =>
+              SequenceOp(OpCode.EVAL_STRATUM,
+                naiveEval(rules, true),
+                DoWhileOp(
+                  DB.Delta,
+                  SequenceOp(OpCode.LOOP_BODY,
+                    SwapAndClearOp(),
+                    semiNaiveEval(ctx.toSolve, rules.view)
+                  )
+                ),
+                UpdateDiscoveredOp(),
+              ),
+            ): _*,
+          ),
+        )
       case _ => throw new Exception("Non-root passed to IR Program")
     }
   }


### PR DESCRIPTION
This PR builds on top of #29 and implements stratification in the `StagedExecutionEngine`. Moreover, it improves the performance of evaluation by specifying the target relation when computing the strongly connected components in `PrecedenceGraph`.

The following changes are included:

- [x] `IRTreeGenerator` generates generates programs in strata;
- [x] the `UpdateDiscoveredOp` `IROp` is added; it maps to `StorageManager#updatedDiscovered`;
- [x] (bugfix) the naive algorithm from `StagedExecutionEngine` now uses a `ProgramOp` at its top-level;
- [x] `NaiveExecutionEngine`, `SemiNaiveExecutionEngine` and `StagedExecutionEngine` now specify the target predicate when computing strata.